### PR TITLE
Explicitly declare repositories for Gradle plugins

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
 rootProject.name = "save-backend-tests"
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
Apparently, Gradle still uses `jcenter` with higher priority by default. When importing the project, I got a weird error caused by failed download of `kotlin-compiler-embeddable` from `jcenter`, which is required by `kotlin-gradle-plugin`.